### PR TITLE
indent until_time if statement for non feed in parse_int_time

### DIFF
--- a/SigSci.py
+++ b/SigSci.py
@@ -1013,12 +1013,12 @@ class SigSciAPI(object):
 
             self.from_time = self.to_epoch(now, self.from_time)
 
-        if self.until_time is None:
-            # set until time to 7 days after from time
-            self.until_time = int(self.from_time) + (86400 * 7)
-        else:
-            self.until_specified = True
-            self.until_time = self.to_epoch(now, self.until_time)
+            if self.until_time is None:
+                # set until time to 7 days after from time
+                self.until_time = int(self.from_time) + (86400 * 7)
+            else:
+                self.until_specified = True
+                self.until_time = self.to_epoch(now, self.until_time)
 
         # if until time is beyond now, set it to now.
         if self.until_time > calendar.timegm(now.utctimetuple()):


### PR DESCRIPTION
Ran into the below error when running this `python SigSci.py --feed`
```
Traceback (most recent call last):
  File "SigSci.py", line 1235, in <module>
    sigsci.parse_init_time()
  File "SigSci.py", line 1021, in parse_init_time
    self.until_time = self.to_epoch(now, self.until_time)
  File "SigSci.py", line 1031, in to_epoch
    if value.startswith('-'):
AttributeError: 'int' object has no attribute 'startswith'
```