### PR TITLE
output object per line

### DIFF
--- a/SigSci.py
+++ b/SigSci.py
@@ -448,7 +448,9 @@ class SigSciAPI(object):
             if 'message' in j:
                 raise ValueError(j['message'])
 
-            self.output_results(j['data'])
+            d = j['data']
+            for x in d:
+                self.output_results(x)
 
             # get all next
             next_ref = j['next']
@@ -467,7 +469,9 @@ class SigSciAPI(object):
                 if 'message' in j:
                     raise ValueError(j['message'])
 
-                self.output_results(j)
+                d = j['data']
+                for x in d:
+                    self.output_results(x)
 
                 next_ref = j['next']
 


### PR DESCRIPTION
Current `get_feed_requests` outputs every new line as an array of return request objects.  

```
[{"id":1234255...},{"id":123124124...} x 1000]
[{"id":1231245...},{"id":122314124...} x 1000]
[{"id":1255555...},{"id":128784124...} x 1000]
``` 

This outputs it so that every request object takes it own new line.  
```
{"id":12345...}
{"id":65433...}
{"id":88128...}
```

Found it to be easier to handle and use with our chosen siem service.  Let me know what you think, if you think it's good enough but as an additional output option, I can write something utilizing a `---feed-output` flag or something like that. 