### PR TITLE
Add polling commands to poll for new requests and events

### DIFF
--- a/SigSci.py
+++ b/SigSci.py
@@ -730,7 +730,6 @@ class SigSciAPI():
             print('Query: %s ' % url)
             sys.exit()
 
-
     def get_timeseries(self, tags, rollup=60):
         """
         SigSciAPI.get_timeseries(tag, rollup)


### PR DESCRIPTION
Hey all,

We were trying to ingest SigSci data into elasticsearch in a convenient way and since we had fluentbit set up to pipe JSON log output into ES, this seemed like a viable approach. That said, this is set to poll pretty aggressively by default (we'd like to have data be as close to live as possible). I wanted to get feedback on whether this would be too much or if there were any other adjustments you'd like us to make. Also if this would be useful to other customers, feel free to merge.
